### PR TITLE
Removed invalid call of `new` against Promise.resolve

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ class Assets {
     };
 
     this.hooks = {
-      's3deploy:deploy': () => new Promise.resolve().then(this.deployS3.bind(this))
+      's3deploy:deploy': () => Promise.resolve().then(this.deployS3.bind(this))
     };
   }
 


### PR DESCRIPTION
`Promise.resolve` is not a constructor so shouldn't be called with `new`